### PR TITLE
Add Dependabot configuration for Docker Compose images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  # backends/trtllm の Docker イメージ
+  - package-ecosystem: "docker-compose"
+    directory: "/backends/trtllm"
+    schedule:
+      interval: "weekly"
+
+  # backends/vllm の Docker イメージ
+  - package-ecosystem: "docker-compose"
+    directory: "/backends/vllm"
+    schedule:
+      interval: "weekly"
+
+  # backends/nim の Docker イメージ
+  - package-ecosystem: "docker-compose"
+    directory: "/backends/nim"
+    schedule:
+      interval: "weekly"
+
+  # GitHub Actions（将来追加された場合に備える）
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

- Docker Compose イメージの週次更新監視を設定（trtllm, vllm, nim）
- GitHub Actions ワークフローの監視を追加（将来の追加に備える）

## Notes

- `openresty/openresty:alpine`（Docker Hub）は認証なしで更新検出可能
- `nvcr.io` イメージ（NGC）はプライベートレジストリのため、現時点では更新検出不可。必要に応じて `registries` セクションと NGC_API_KEY シークレットを追加

## Test plan

- [x] GitHub リポジトリの Security > Dependabot で設定が認識されていることを確認
- [ ] Insights > Dependency graph > Dependabot タブで監視対象が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
