### PR TITLE
Bump nvcr.io/nvidia/vllm from 26.01-py3 to 26.03-py3 (partial)

### DIFF
--- a/backends/vllm/compose.yml
+++ b/backends/vllm/compose.yml
@@ -1,5 +1,5 @@
 x-common: &common
-  image: nvcr.io/nvidia/vllm:26.01-py3
+  image: nvcr.io/nvidia/vllm:26.03-py3
   restart: unless-stopped
   ipc: host
   ports:
@@ -188,7 +188,7 @@ services:
 
   vllm-multi-nemotron:
     <<: *common
-    # NemotronH + NVFP4 は 26.01 必須。ドライバ 580 では Forward Compat を独占使用
+    # NemotronH + NVFP4 は 26.03 (CUDA 13.2)。ドライバ 580 では Forward Compat を独占使用
     profiles: ["multi"]
     ports: []
     healthcheck:


### PR DESCRIPTION
> Draft: blocked on NVIDIA driver 595.45+. See "Blocker" below.

## Summary
- Update `x-common` image from `26.01-py3` to `26.03-py3` (CUDA 13.2, vLLM 0.17.1)
- Keep `vllm-multi-qwen` on `25.11-py3` to avoid Forward Compat conflict on driver 580
- Supersedes Dependabot PR #29

## Blocker: driver 580 is incompatible with 26.03

The `nvcr.io/nvidia/vllm:26.03-py3` container requires **NVIDIA driver 595.45 or later**. On DGX Spark's current driver 580.142, the container prints on every start:

```
ERROR: This container was built for NVIDIA Driver Release 595.45 or later, but
       version 580.142 was detected and compatibility mode is UNAVAILABLE.
```

Non-NVFP4 paths (qwen bf16) appear to work initially, but NVFP4 paths (nemotron) crash with `CUDA error: an illegal memory access was encountered` after a small number of requests. Subsequent requests then hit `CUBLAS_STATUS_EXECUTION_FAILED` and the engine stays dead until the container restarts.

This PR will remain in draft until the DGX Spark driver is updated to 595.45+.

## Verification results (DGX Spark, driver 580.142)

| Profile | Result | Notes |
|---------|--------|-------|
| qwen | OK (caveat) | Single request works. Not retested under sustained load after the nemotron finding. |
| nemotron | **NG** | First 1-2 requests succeed, then `CUDA illegal memory access`; engine never recovers. Verified on both streaming and non-streaming. |
| nemotron-vl | NG | `--limit-mm-per-prompt` format changed in vLLM 0.17.1 (pre-existing, not in use). |
| multi | **NG** | Nemotron side crashes the same way. Also required bumping `vllm-multi-qwen` `--gpu-memory-utilization` from 0.52 to 0.55 due to a 230 MiB KV cache shortfall on re-measurement (reverted; unrelated to 26.03 bump). |

## Root cause

NVFP4 kernels introduced/updated in vLLM 0.17.1 (26.03) depend on driver features not covered by CUDA Forward Compat for driver 580. The container's own startup message declares compatibility mode unavailable, which matches the runtime symptom.

## Options (for later)

- **Wait for driver 595+** on DGX Spark and re-verify (preferred).
- Alternative narrow scope: keep `x-common` on 26.03 but pin `vllm-nemotron` and `vllm-multi-nemotron` to `26.01-py3` explicitly. Not done here because it would ship a split toolchain that's harder to maintain and obscures the driver blocker.

## Test plan
- [x] Step 1: Confirmed 26.03 uses CUDA 13.2 and requires driver 595.45+ (container emits UNAVAILABLE message on driver 580).
- [x] Step 2a: qwen profile - basic inference OK.
- [x] Step 2b: nemotron profile - **NG**, illegal memory access after 2-3 requests (streaming and non-streaming).
- [x] Step 2c: nemotron-vl profile - `--limit-mm-per-prompt` breakage (pre-existing).
- [x] Step 3: multi profile - **NG**, same nemotron crash; `/health`, `/v1/models`, first inference pass, but sustained streaming / later requests crash the engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)